### PR TITLE
Corrected @whereConstraints documentation

### DIFF
--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -2900,7 +2900,7 @@ type Person {
     age: Int!
     height: Int!
     type: String!
-    hair_color: String!
+    hair_colour: String!
 }
 
 type Query {

--- a/docs/master/api-reference/directives.md
+++ b/docs/master/api-reference/directives.md
@@ -2906,7 +2906,7 @@ type Person {
 type Query {
     people(
         where: WhereConstraints @whereConstraints
-    ): [Person!]!
+    ): [Person!]! @all
 }
 ```
 
@@ -2951,7 +2951,7 @@ By default, the `@whereConstraints` directive allows for filtering on all fields
 type Query {
     people(
         where: WhereConstraints @whereConstraints(columns: ["age", "height"])
-    ): [Person!]!
+    ): [Person!]! @all
 }
 ```
 
@@ -2980,7 +2980,7 @@ type Query {
     people(
         # Be sue to change to your newly-defined input.
         where: PeopleWhereConstraints @whereConstraints
-    ): [Person!]!
+    ): [Person!]! @all
 }
 ```
 


### PR DESCRIPTION
The documentation gave example code that would not run. As well the documentation was somewhat unclear about the use of the default `WhereConstraints` input vs a custom input.

- Expanded and clarified the usage of the directive and inputs.
- Corrected code examples to remove typos, unterminated strings, missing commas, and to work for the different input examples.
- Corrected various typos in the text.

- [ ] Added or updated tests
- [ ] Added Docs for all relevant versions
- [ ] Updated CHANGELOG.md

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

**Breaking changes**

<!-- If there are any breaking changes, list them here.
Make sure to mention them in UPGRADE.md. -->
